### PR TITLE
Adding package metadata and python version constraint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,37 @@
+[metadata]
+name = sgkit-plink
+author = sgkit Developers
+license = Apache
+description = PLINK IO implementations for sgkit
+long_description_content_type=text/x-rst
+long_description =
+    **sgkit-plink** contains block array readers for large-scale genomic data stored as PLINK
+url = https://github.com/pystatgen/sgkit
+classifiers =
+    Development Status :: 2 - Pre-Alpha
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+    Intended Audience :: Science/Research
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Scientific/Engineering
+
+[options]
+packages = sgkit_plink
+zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
+include_package_data = True
+python_requires = >=3.7
+install_requires =
+    numpy
+    xarray
+    pysnptools >= 0.4.19
+    setuptools >= 41.2  # For pkg_resources
+setup_requires =
+    setuptools >= 41.2
+    setuptools_scm
+
 [coverage:report]
 fail_under = 100
 

--- a/sgkit_plink/pysnptools.py
+++ b/sgkit_plink/pysnptools.py
@@ -272,7 +272,6 @@ def read_plink(
 
     # Note: column_stack not implemented in Dask, must use [v|h]stack
     variant_alleles = da.hstack((a1[:, np.newaxis], a2[:, np.newaxis]))
-    # TODO: Why use bytes for this instead of string?
     variant_alleles = variant_alleles.astype("S")
     variant_id = arr_bim["variant_id"]
 


### PR DESCRIPTION
This is a fix for https://github.com/pystatgen/sgkit-plink/issues/4, which makes python 3.7 the minimum supported version.