### PR TITLE
Initial cli

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ ignore =
 [isort]
 default_section = THIRDPARTY
 known_first_party = sgkit
-known_third_party = dask,numpy,pysnptools,pytest,xarray
+known_third_party = dask,numpy,pysnptools,pytest,setuptools,xarray
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0
@@ -62,3 +62,7 @@ ignore_missing_imports = True
 
 [mypy-sgkit_plink.tests.*]
 disallow_untyped_defs = False
+
+[options.entry_points]
+console_scripts =
+    plink2sg = sgkit_plink.cli:plink2sg_main

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+from setuptools import setup
+
+setup(use_scm_version=True)

--- a/sgkit_plink/__main__.py
+++ b/sgkit_plink/__main__.py
@@ -1,0 +1,4 @@
+from . import cli
+
+if __name__ == "__main__":
+    cli.sgkit_plink_main()

--- a/sgkit_plink/cli.py
+++ b/sgkit_plink/cli.py
@@ -1,0 +1,95 @@
+"""
+Command line utilities for conversion.
+"""
+import argparse
+import os
+import signal
+
+from dask.diagnostics import ProgressBar
+
+from . import read_plink
+
+
+def set_sigpipe_handler():
+    if os.name == "posix":
+        # Set signal handler for SIGPIPE to quietly kill the program.
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+
+def run_plink2sg(args):
+    # TODO add args for bim and fam seps
+    # TODO add logging and verbosity so we can write out info messages
+    # about what we're doing here.
+    ds = read_plink(args.plink_path, bim_sep=" ", fam_sep=" ")
+
+    # TODO add a command line options for this progess bar.
+    with ProgressBar():
+
+        # TODO Do the dask compute manually so that we can have
+        # more influence over the number of threads used.
+
+        # TODO add options to give more control over the zarr
+        # format used. We probably want to have the option of
+        # writing to a ZipFile anyway, so that we don't have
+        # gazillions of files.
+
+        # TODO catch keyboard interrups here, clean up the
+        # zarr file, and write a meaningful error message.
+        ds.to_zarr(args.sgkit_path, mode="w")
+    # TODO write out an INFO summary of the size of the
+    # input and output
+
+
+def add_plink2sg_arguments(parser):
+
+    # TODO we don't seem to have an __version__ defined yet.
+    # parser.add_argument(
+    #     "-V",
+    #     "--version",
+    #     action="version",
+    #     version=f"%(prog)s {sgkit_plink.__version__}",
+    # )
+
+    parser.add_argument("plink_path", help="The plink dataset to read")
+    parser.add_argument("sgkit_path", help="The path to write the converted dataset to")
+
+
+def get_plink2sg_parser(parser=None):
+
+    parser = argparse.ArgumentParser(description="Convert plink files to sgkit format")
+    add_plink2sg_arguments(parser)
+
+    return parser
+
+
+def get_sgkit_plink_parser():
+    top_parser = argparse.ArgumentParser(
+        description=("Utilities for converting data from plink to sgkit and vice versa")
+    )
+    subparsers = top_parser.add_subparsers(dest="subcommand")
+    subparsers.required = True
+    parser = subparsers.add_parser("plink2sg")
+    parser.set_defaults(runner=run_plink2sg)
+    add_plink2sg_arguments(parser)
+    # TODO add sg2plink also
+    return top_parser
+
+
+def plink2sg_main(arg_list=None):
+    """
+    Top-level hook for the plink2sg console script.
+    """
+    parser = get_plink2sg_parser()
+    args = parser.parse_args(arg_list)
+    args.runner(args)
+
+
+def sgkit_plink_main(arg_list=None):
+    """
+    Top-level hook called when running python -m sgkit_plink. Just
+    exists to call plink2sg or sg2plink as subcommands.
+    """
+    parser = get_sgkit_plink_parser()
+    set_sigpipe_handler()
+    args = parser.parse_args(arg_list)
+    args.runner(args)


### PR DESCRIPTION
Closes #7 

This is an initial outline of the conversion CLI.

I haven't written any testing code yet, as I wanted to see if people agreed with the basic organisation first (and ran out of time!).

This adds a ``plink2sg`` CLI that can be run either via ``python -m sgkit_plink plink2sg`` or via ``plink2sg``, if the package has been installed and the user's PATH set up accordingly. There's a bit of indirection needed to do this, but I think it's worth it as it's always useful to be able to use the ``python -m `` version. I haven't made ``python -m sgkit_plink`` call ``plink2sg`` directly because I think we'll inevitably need to have another method, ``sg2plink``, which does the conversion in the other direction. There's some extra stuff in there that will facilitate testing, also, and having it broken up into little pieces makes things easier to mock out.

What do we think of this organisation? Do we like the names?